### PR TITLE
docs: add SECURITY.md and Docusaurus legal pages (Terms & Privacy)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+Thank you for helping keep Compute Intelligence Graph (CIG) secure.
+
+## Supported Versions
+
+Security fixes are prioritized for the latest code on the `main` branch and the latest published releases.
+
+| Version | Supported |
+| --- | --- |
+| Latest `main` | ✅ |
+| Latest release line | ✅ |
+| Older release lines | ⚠️ Best effort |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities in public GitHub issues.
+
+Instead, use one of the following private channels:
+
+- Open a **GitHub Security Advisory** draft in this repository.
+- Email the maintainers at **security@cig.lat** (include reproducible steps, impact, and affected components).
+
+When reporting, please include:
+
+1. A clear description of the vulnerability.
+2. Affected service/package and version or commit SHA.
+3. Reproduction steps or proof of concept.
+4. Security impact and likely attack scenario.
+5. Any suggested remediation.
+
+## Disclosure Process
+
+1. We acknowledge receipt within **3 business days**.
+2. We triage and assess severity.
+3. We develop and validate a fix.
+4. We coordinate disclosure timing with the reporter.
+5. We publish remediation details in release notes or advisories.
+
+## Legal and Platform Policies
+
+For legal terms and data processing details, see:
+
+- Terms of Service: <https://cig.lat/documentation/docs/en/legal/terms-of-service>
+- Privacy Policy: <https://cig.lat/documentation/docs/en/legal/privacy-policy>
+
+## Scope Notes
+
+- CIG technology and code are open source.
+- The CIG platform brand assets and trademarks are associated with **LSTS**.

--- a/apps/docs/docs/en/legal/index.md
+++ b/apps/docs/docs/en/legal/index.md
@@ -1,0 +1,13 @@
+---
+id: index
+title: Legal
+description: Legal information for Compute Intelligence Graph (CIG).
+sidebar_position: 1
+---
+
+# Legal
+
+This section includes policies that govern use of CIG services and websites.
+
+- [Terms of Service](./terms-of-service)
+- [Privacy Policy](./privacy-policy)

--- a/apps/docs/docs/en/legal/privacy-policy.md
+++ b/apps/docs/docs/en/legal/privacy-policy.md
@@ -1,0 +1,144 @@
+---
+id: privacy-policy
+title: Privacy Policy
+description: Privacy Policy for Compute Intelligence Graph (CIG).
+sidebar_position: 3
+---
+
+# Privacy Policy
+
+**Last updated:** March 28, 2026
+
+This Privacy Policy explains how Compute Intelligence Graph ("CIG", "we", "us") collects, uses, discloses, and safeguards personal data when you use our websites, documentation, APIs, and related services (the "Services").
+
+## 1. Scope
+
+This policy applies to personal data processed through CIG-operated Services. It does not directly cover third-party services integrated by users or linked from CIG.
+
+## 2. Data We Collect
+
+Depending on your usage, we may process the following categories of data:
+
+### a) Account and Profile Data
+
+- Name, email address, organization, role.
+- Authentication identifiers and account metadata.
+
+### b) Service Usage Data
+
+- Feature usage events.
+- API request metadata (timestamps, endpoint, response codes, request size).
+- Device/browser details and approximate geolocation inferred from IP.
+
+### c) Technical and Security Data
+
+- Log files, telemetry, diagnostics, and crash reports.
+- Security events, access logs, abuse detection signals.
+- Session identifiers and anti-fraud indicators.
+
+### d) Content and Inputs
+
+- Content, prompts, files, and graph data you submit to the Services.
+- Generated outputs and related operational metadata.
+
+### e) Communications Data
+
+- Support tickets, feedback, issue reports, and policy inquiries.
+
+## 3. How We Use Data
+
+We use personal data to:
+
+1. Provide and operate the Services.
+2. Authenticate users and secure accounts.
+3. Maintain reliability, performance, and safety.
+4. Detect, investigate, and prevent abuse or unlawful activity.
+5. Respond to support requests and communicate service updates.
+6. Comply with legal obligations.
+7. Improve product functionality and user experience.
+
+We do **not** sell personal data.
+
+## 4. Legal Bases (Where Applicable)
+
+Depending on jurisdiction, we rely on one or more legal bases:
+
+- Contract performance (providing requested Services).
+- Legitimate interests (security, reliability, anti-abuse, operations).
+- Consent (where required, e.g., optional communications/cookies).
+- Legal obligation (compliance, lawful requests, recordkeeping).
+
+## 5. Cookies and Similar Technologies
+
+We may use cookies/local storage for:
+
+- Authentication/session continuity.
+- Preferences and UX state.
+- Security controls.
+- Analytics (where configured).
+
+You can manage cookies in browser settings, though disabling some may affect functionality.
+
+## 6. Sharing and Disclosure
+
+We may share data with:
+
+- Infrastructure, hosting, analytics, and support vendors under contractual safeguards.
+- Affiliates and project operators involved in delivering the Services.
+- Legal authorities when required by law or valid legal process.
+- Security researchers/reporters during coordinated response where necessary.
+
+We may disclose aggregated or de-identified information that does not reasonably identify individuals.
+
+## 7. International Transfers
+
+Data may be processed in countries different from your own. When required, we use appropriate safeguards (such as contractual protections) for cross-border transfers.
+
+## 8. Data Retention
+
+We retain data for as long as needed to:
+
+- Provide Services you request.
+- Maintain security and audit integrity.
+- Comply with legal, regulatory, tax, or accounting obligations.
+- Resolve disputes and enforce agreements.
+
+Retention periods vary by data type and risk profile.
+
+## 9. Security Measures
+
+We use administrative, technical, and organizational safeguards designed to protect personal data. No system is perfectly secure; users should also protect credentials and use secure operational practices.
+
+## 10. Your Privacy Rights
+
+Subject to local law, you may have rights to:
+
+- Access personal data.
+- Correct inaccurate data.
+- Delete data.
+- Restrict or object to processing.
+- Data portability.
+- Withdraw consent where processing relies on consent.
+- Lodge a complaint with a regulator.
+
+To exercise rights, contact **privacy@cig.lat**.
+
+## 11. Children’s Privacy
+
+The Services are not directed to children under the age where parental consent is required by law. If we learn we have collected such data without valid authorization, we will take appropriate action.
+
+## 12. Open-Source and Trademark Clarification
+
+- CIG technology is open source under applicable licenses.
+- Platform brand assets and trademarks are associated with **LSTS**.
+- Open-source access does not itself grant trademark rights.
+
+## 13. Changes to This Policy
+
+We may update this Privacy Policy from time to time. Material updates will be posted with a revised "Last updated" date.
+
+## 14. Contact
+
+Privacy requests: **privacy@cig.lat**  
+Security reports: **security@cig.lat**  
+Legal inquiries: **legal@cig.lat**

--- a/apps/docs/docs/en/legal/terms-of-service.md
+++ b/apps/docs/docs/en/legal/terms-of-service.md
@@ -1,0 +1,94 @@
+---
+id: terms-of-service
+title: Terms of Service
+description: Terms of Service for Compute Intelligence Graph (CIG).
+sidebar_position: 2
+---
+
+# Terms of Service
+
+**Last updated:** March 28, 2026
+
+These Terms of Service ("Terms") govern your access to and use of the Compute Intelligence Graph ("CIG") websites, documentation, APIs, and related services (collectively, the "Services"). By using the Services, you agree to these Terms.
+
+## 1. Operator and Open-Source Notice
+
+- The CIG technology stack is open source and may be used under the applicable repository license(s).
+- The CIG platform identity, brand assets, and trademarks are associated with **LSTS**.
+- Open-source license permissions do not grant rights to use protected names, logos, trade dress, or trademarks except as explicitly allowed by LSTS policy or written permission.
+
+## 2. Eligibility and Account Responsibility
+
+You must be legally able to enter into a binding agreement and comply with applicable laws. You are responsible for:
+
+- Maintaining account confidentiality and credential security.
+- All activity under your account.
+- Promptly notifying us of unauthorized access or misuse.
+
+## 3. Acceptable Use
+
+You agree not to use the Services to:
+
+- Violate law, regulation, or third-party rights.
+- Interfere with service integrity, availability, or security.
+- Access systems or data without authorization.
+- Upload or transmit malware, abusive content, or fraud.
+- Conduct benchmark abuse, scraping abuse, denial-of-service, or exploit attempts.
+
+We may suspend or terminate access for activity that creates security, legal, or operational risk.
+
+## 4. API and Service Limits
+
+Service quotas, rate limits, and fair-use controls may apply. You agree not to bypass technical limits. We may change limits, deprecate endpoints, or modify service features to maintain reliability and security.
+
+## 5. Intellectual Property
+
+- You retain rights to content you lawfully submit.
+- You grant us a limited, non-exclusive license to host/process submitted content solely to operate, secure, and improve the Services.
+- Except for open-source code under its licenses, all service UI, branding, and trademarks remain property of their owners, including LSTS marks related to the platform.
+
+## 6. Privacy and Data Handling
+
+Your use of the Services is also governed by the [Privacy Policy](./privacy-policy), which describes how data is collected and used.
+
+## 7. Third-Party Services
+
+The Services may integrate third-party tools, storage, authentication, or cloud infrastructure. We are not responsible for third-party services outside our control; their terms and policies apply independently.
+
+## 8. Security and Responsible Disclosure
+
+If you discover a vulnerability, follow the process in the repository `SECURITY.md`. Do not publicly disclose vulnerabilities before coordinated remediation.
+
+## 9. Service Availability and Changes
+
+The Services are provided on an evolving basis and may change at any time. We may update, pause, or discontinue parts of the Services with reasonable notice when practical.
+
+## 10. Disclaimers
+
+To the extent permitted by law, the Services are provided "as is" and "as available" without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, non-infringement, and uninterrupted availability.
+
+## 11. Limitation of Liability
+
+To the maximum extent permitted by law, CIG operators, maintainers, and contributors are not liable for indirect, incidental, special, consequential, or punitive damages, or lost profits/data/revenue arising from your use of or inability to use the Services.
+
+## 12. Indemnification
+
+You agree to defend and indemnify CIG operators and contributors against claims, losses, and expenses (including legal fees) arising from your misuse of the Services, your violation of these Terms, or your violation of law or third-party rights.
+
+## 13. Termination
+
+You may stop using the Services at any time. We may suspend or terminate access where required for security, legal compliance, abuse prevention, or operational protection.
+
+## 14. Governing Law and Disputes
+
+Unless otherwise required by applicable law, disputes are governed by the laws and venue designated by the operating legal entity for the service deployment you use. Where mandatory consumer protections apply, those protections remain in force.
+
+## 15. Changes to These Terms
+
+We may revise these Terms periodically. Updated versions are effective when posted with a new "Last updated" date. Continuing to use the Services after changes means you accept the revised Terms.
+
+## 16. Contact
+
+For legal or policy inquiries, contact: **legal@cig.lat**
+
+For security reports, contact: **security@cig.lat**

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -89,6 +89,15 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Legal',
+      items: [
+        'en/legal/index',
+        'en/legal/terms-of-service',
+        'en/legal/privacy-policy',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Resources',
       items: [
         'en/project-status',

--- a/apps/docs/src/theme/Footer/index.tsx
+++ b/apps/docs/src/theme/Footer/index.tsx
@@ -24,6 +24,8 @@ export default function Footer(): JSX.Element {
     { label: 'GitHub', href: 'https://github.com/edwardcalderon/ComputeIntelligenceGraph' },
     { label: 'Issues', href: 'https://github.com/edwardcalderon/ComputeIntelligenceGraph/issues' },
     { label: 'Report', href: 'https://github.com/edwardcalderon/ComputeIntelligenceGraph/issues/new' },
+    { label: 'Terms', href: '/documentation/docs/en/legal/terms-of-service' },
+    { label: 'Privacy', href: '/documentation/docs/en/legal/privacy-policy' },
     { label: 'Landing', href: landingUrl },
   ];
 


### PR DESCRIPTION
### Motivation

- Provide an official security disclosure workflow and supported-versions guidance for the project.
- Publish comprehensive legal pages (Terms of Service and Privacy Policy) for the Docusaurus documentation site and link them from the docs UI.
- Clarify project legal notes that the CIG technology is open source and that platform/trademark assets are associated with LSTS.

### Description

- Added a repository-level `SECURITY.md` that describes supported versions, private vulnerability reporting channels, a disclosure timeline, and links to legal policies.
- Added Docusaurus docs under `apps/docs/docs/en/legal/` including `index.md`, `terms-of-service.md`, and `privacy-policy.md` with comprehensive policy text and contact addresses (`legal@cig.lat`, `privacy@cig.lat`, `security@cig.lat`).
- Updated the docs sidebar at `apps/docs/sidebars.ts` to add a new `Legal` category linking the index, terms, and privacy pages.
- Updated the custom docs footer component `apps/docs/src/theme/Footer/index.tsx` to include direct `Terms` and `Privacy` links.

### Testing

- Built the docs site with `pnpm --filter @cig/docs build` and the Docusaurus build completed successfully and generated static files.
- No other automated tests were modified or required for these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c71ee4447c833297025394ac80cd85)